### PR TITLE
Fix: revert to old executable name

### DIFF
--- a/objpoke-cli/Cargo.toml
+++ b/objpoke-cli/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/tux3/objpoke/"
 categories = ["command-line-utilities", "development-tools::build-utils"]
 description = "Minimal in-place objcopy replacement"
 
+[[bin]]
+name = "objpoke"
+path = "src/main.rs"
+
 [dependencies]
 objpoke = { path = "../objpoke" }
 anyhow = { workspace = true, features = ["backtrace"] }


### PR DESCRIPTION
In the last PR I accidentally renamed the CLI utility from `objpoke` to `objpoke-cli`, sorry about that.

This PR reverts to the old name (`objpoke`).